### PR TITLE
🔖 Release Ditto 1.1.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,8 +16,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "DittoSwift",
-            url: "https://github.com/getditto/DittoSwift/releases/download/1.1.0/DittoSwift.xcframework.zip",
-            checksum: "18ea89247e58cc0b279929a8ad472dac306b96c007d81ed25b6d1b5bc75f4c23"
+            url: "https://github.com/getditto/DittoSwift/releases/download/1.1.1/DittoSwift.xcframework.zip",
+            checksum: "0c4518ab8affb5b4e09c91f75ef46ab76c33be2735c52b16d4b58b189807e88b"
         ),
         .binaryTarget(
             name: "DittoObjC",

--- a/Package.swift
+++ b/Package.swift
@@ -21,8 +21,8 @@ let package = Package(
         ),
         .binaryTarget(
             name: "DittoObjC",
-            url: "https://github.com/getditto/DittoObjC/releases/download/1.1.0/DittoObjC.xcframework.zip",
-            checksum: "f4e1ea50cc21986f7cb23c2be50519d61cea43b99d50ddff794b4a164dd4cd27"
+            url: "https://github.com/getditto/DittoObjC/releases/download/1.1.1/DittoObjC.xcframework.zip",
+            checksum: "8a4f656e05ab45b143b371e472f335d945fa6c03528d1904b575a36ca36114ee"
         ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
         .binaryTarget(
             name: "DittoSwift",
             url: "https://github.com/getditto/DittoSwift/releases/download/1.1.1/DittoSwift.xcframework.zip",
-            checksum: "0c4518ab8affb5b4e09c91f75ef46ab76c33be2735c52b16d4b58b189807e88b"
+            checksum: "9bbf1d367c62eb39d6bb9c5b48f7bffd2c906573ed065a562cff2df5ec3ec81c"
         ),
         .binaryTarget(
             name: "DittoObjC",


### PR DESCRIPTION
## DittoSwift

- Added: Combine publisher APIs obviating the CombineDitto extension library
  - Added: `remotePeersPublisher()` method to `Ditto` class
  - Added: `fetchAttachmentPublisher(attachmentToken:)` method to `DittoCollection` class
  - Added: `liveQueryPublisher()` method to `DittoPendingCursorOperation` class
  - Added: `singleDocumentLiveQueryPublisher()` method to `DittoPendingIDSpecificOperation` class
- Added: Experimental Bus API
  - Added: `dittoBus(_, didReceiveSingleMessage:)` method to `DittoBusDelegate` protocol
  - Added: `dittoBus(_, didReceiveIncomingStream:, fromPeer:)` method to `DittoBusDelegate` protocol
  - Removed: `dittoBus(_, didReceive:)` method from `DittoBusDelegate protocol
- Added: Experimental mesh roles API
  - Added: `setMeshRole(meshRole:, ditto:)` method to `DittoExperimental` class
  - Added: `setPriorityForMeshRole(_, forMeshRole:, ditto:)` to `DittoExperimental` class
- Fixed: Improved AWDL reliability on iOS 12

## DittoObjC

- Added: Experimental Bus API
  - Changed: `DITBus.delegate` property is now weak
  - Added: `-sendSingleUnreliableMessage:toAddress:completion:` method to `DITBus` class
  - Added: `-sendSingleReliableMessage:toAddress:completion:` method to `DITBus` class
  - Added: `-openStreamToAddress:reliability:completion:` method to `DITBus` class
  - Added: `-ditBus:didReceiveSingleMessage:` method to `DITBusDelegate` protocol
  - Added: `-ditBus:didReceiveIncomingStream:fromPeer:` method to `DITBusDelegate` protocol
  - Removed: `-ditBus:didReceiveMessage:` method from `DITBusDelegate` protocol
  - Added: `DITBusStream` class
  - Added: `DITBusStreamDelegate` protocol
- Added: Experimental mesh roles API
  - Added: `-setMeshRole(meshRole:ditto:)` method to `DITExperimental` class
  - Added: `-setPriorityForMeshRole(_:forMeshRole:ditto:)` to `DITExperimental` class
- Fixed: Improved AWDL reliability on iOS 12