### PR TITLE
🔖 Version 4.6.0-rc.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,13 +23,13 @@ let package = Package(
         ),
         .binaryTarget(
             name: "DittoSwift",
-            url: "https://software.ditto.live/cocoa/DittoSwift/4.5.4/dist/DittoSwift.xcframework.zip",
-            checksum: "d5ab849b194d6d4e0f66e6a3211d0cfdc94921469126484d9361b530ee5a5624"
+            url: "https://software.ditto.live/cocoa/DittoSwift/4.6.0-rc.1/dist/DittoSwift.xcframework.zip",
+            checksum: "20de60cf8a3532af927efb5f0d0d01fa69ffbb3d211de2153c3517148c80781c"
         ),
         .binaryTarget(
             name: "DittoObjC",
-            url: "https://software.ditto.live/cocoa/DittoObjC/4.5.4/dist/DittoObjC.xcframework.zip",
-            checksum: "d34100e7f755ee61161a3f3d048113ffd8289ba41f552807c61c60853064fecc"
+            url: "https://software.ditto.live/cocoa/DittoObjC/4.6.0-rc.1/dist/DittoObjC.xcframework.zip",
+            checksum: "ffd914ae7188d093f387f677b9a9282597f9edfc02fb08445760160032c71581"
         ),
     ]
 )


### PR DESCRIPTION
The automated release process failed to update the `main` branch again, but it did update the `Package.swift` file which it tagged as [`4.6.0-rc.1`](https://github.com/getditto/DittoSwiftPackage/releases/tag/4.6.0-rc.1). This `4.6.0-rc.1` release can be tested now before this PR is merged.

https://github.com/getditto/DittoSwiftPackage/blob/4.6.0-rc.1/Package.swift