### PR TITLE
Bump the minimum iOS version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "Ditto",
-    platforms: [ .iOS(.v11), .macOS(.v11) ],
+    platforms: [ .iOS(.v14), .macOS(.v11) ],
     products: [
         .library(
             name: "DittoSwift",


### PR DESCRIPTION
# Details

Since SDK version 4.5, [the Swift SDK requires iOS 14 or later](https://docs.ditto.live/ios/installation#HHTe7), but we have omitted updating it in this repo.

N.B. There's no need to update the macOS version since it hasn't changed.

## Additional Context

See [this proposal](https://www.notion.so/getditto/Drop-Support-for-Legacy-iOS-and-iPadOS-Versions-a525c4a995494ffea91f854633fa4781?pvs=4) for more details.

Also, see this [Slack discussion](https://dittolive.slack.com/archives/CQE2DH7AR/p1715174331415629)

## How to Test:

- Point to this branch in any demo app that uses `DittoSwiftPackage`

<img width="1028" alt="Screenshot 2024-05-08 at 9 31 27 AM" src="https://github.com/getditto/DittoSwiftPackage/assets/7443038/565d0f7c-716c-47ab-aa30-4a0f00ce4a6e">

- Go to the File menu > Packages > Reset Package Caches for good measure
- Wait until the download is complete
- Observe that building the app works without any issues.
